### PR TITLE
Fixed some minor errors with const

### DIFF
--- a/include/encoder.h
+++ b/include/encoder.h
@@ -87,8 +87,8 @@ namespace atg_dtv {
             Error m_error;
 
             AVFormatContext *m_oc = nullptr;
-            AVOutputFormat *m_fmt = nullptr;
-            AVCodec *m_videoCodec = nullptr;
+            const AVOutputFormat *m_fmt = nullptr;
+            const AVCodec *m_videoCodec = nullptr;
             OutputStream m_videoStream;
             bool m_openedFile = false;
             int m_lineWidth = 0;

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -73,7 +73,7 @@ void atg_dtv::Encoder::submitFrame() {
 atg_dtv::Encoder::Error addStream(
         atg_dtv::OutputStream *ost,
         AVFormatContext *oc,
-        AVCodec **codec,
+        const AVCodec **codec,
         AVCodecID codecId,
         atg_dtv::Encoder::VideoSettings &settings)
 {
@@ -185,6 +185,7 @@ atg_dtv::Encoder::Error openVideo(
         atg_dtv::OutputStream *ost,
         atg_dtv::Encoder::VideoSettings &settings)
 {
+	(void)oc;
     typedef atg_dtv::Encoder::Error Error;
 
     if (avcodec_open2(ost->codecContext, codec, nullptr) < 0) {
@@ -244,6 +245,7 @@ void generateFrame(
         atg_dtv::OutputStream *ost)
 {
     AVFrame *target = ost->tempFrame;
+	(void)dest;
 
     const int pixelSize = settings.inputAlpha
         ? 4 * sizeof(uint8_t)


### PR DESCRIPTION
A few variables were declared non-`const`, which tripped up g++ on Linux. I also added a few `(void)var` so it wouldn't generate warnings about unused parameters.