### PR TITLE
Added missing string header

### DIFF
--- a/include/encoder.h
+++ b/include/encoder.h
@@ -5,6 +5,7 @@
 
 #include <thread>
 #include <mutex>
+#include <string>
 
 struct AVStream;
 struct AVCodecContext;


### PR DESCRIPTION
Fixes an issue reporting std::string as an incomplete type.
Ran into the issue when compiling with gcc 13.1.1